### PR TITLE
Return an empty object on all 200 OK responses to /transactions

### DIFF
--- a/mautrix_appservice/appservice.py
+++ b/mautrix_appservice/appservice.py
@@ -148,7 +148,7 @@ class AppService:
 
         transaction_id = request.match_info["transaction_id"]
         if transaction_id in self.transactions:
-            return web.Response(status=200)
+            return web.json_response({})  # 200 OK
 
         json = await request.json()
 


### PR DESCRIPTION
Synapse (and the spec) expect an empty object on all 200 OK responses, so we should do that.